### PR TITLE
Fix for nl2br in formbuilder [INTEGRALCS-8877]

### DIFF
--- a/dist/formbuilder.js
+++ b/dist/formbuilder.js
@@ -80,35 +80,33 @@
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
-    FormbuilderModel = (function(_super) {
-        var $wrappers;
+  FormbuilderModel = (function(_super) {
+    var $wrappers;
 
-        __extends(FormbuilderModel, _super);
+    __extends(FormbuilderModel, _super);
 
-        function FormbuilderModel() {
-            _ref = FormbuilderModel.__super__.constructor.apply(this, arguments);
-            return _ref;
-        }
+    function FormbuilderModel() {
+      _ref = FormbuilderModel.__super__.constructor.apply(this, arguments);
+      return _ref;
+    }
 
-        $wrappers = {};
+    $wrappers = {};
 
-        FormbuilderModel.prototype.sync = function() {};
+    FormbuilderModel.prototype.sync = function() {};
 
-        FormbuilderModel.prototype.indexInDOM = function() {
-            if ($wrappers[this.cid] === undefined) {
-                $(".fb-field-wrapper").each((function(_, el) {
-                    $wrappers[$(el).data('cid')] = $(el);
-                    return true;
-                }));
-            }
-            var wrapper = ($wrappers[this.cid] || {
-                index: function() {
-                    return -1;
-                }
-            });
-            var index =  wrapper.index(".fb-field-wrapper");
-            return index;
-        };
+    FormbuilderModel.prototype.indexInDOM = function() {
+      if ($wrappers[this.cid] === 'undefined') {
+        $(".fb-field-wrapper").each((function(_, el) {
+          $wrappers[$(el).data('cid')] = $(el);
+          return true;
+        }));
+        return ($wrappers[this.cid] || {
+          index: function() {
+            return -1;
+          }
+        }).index(".fb-field-wrapper");
+      }
+    };
 
     FormbuilderModel.prototype.is_input = function() {
       return Formbuilder.inputFields[this.get(Formbuilder.options.mappings.TYPE)] != null;
@@ -1418,10 +1416,24 @@
         return (typeof (_base = Formbuilder.fields[type]).defaultAttributes === "function" ? _base.defaultAttributes(attrs, Formbuilder) : void 0) || attrs;
       },
       simple_format: function(x) {
-        return x != null ? x.replace(/\n/g, '<br />') : void 0;
+        var _ref7;
+        return (_ref7 = this.escape_html(x)) != null ? _ref7.replace(/\n/g, '<br />') : void 0;
       },
       clone: function(obj) {
         return JSON.parse(JSON.stringify(obj));
+      },
+      escape_html: function(text) {
+        var map;
+        map = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#039;'
+        };
+        return text.replace(/[&<>"']/g, function(m) {
+          return map[m];
+        });
       }
     };
 
@@ -2809,7 +2821,7 @@ obj || (obj = {});
 var __t, __p = '', __e = _.escape;
 with (obj) {
 __p += '<span class=\'help-block\'>\n  ' +
-__e( Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.DESCRIPTION)) ) +
+((__t = ( Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.DESCRIPTION)) )) == null ? '' : __t) +
 '\n</span>\n';
 
 }
@@ -2848,7 +2860,7 @@ with (obj) {
 __p += '<label>\n  <span style="color: ' +
 __e( rf.get(Formbuilder.options.mappings.LABEL_COLOR) || '#000' ) +
 '">' +
-__e( Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.LABEL)) ) +
+((__t = ( Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.LABEL)) )) == null ? '' : __t) +
 '\n  ';
  if (rf.get(Formbuilder.options.mappings.REQUIRED)) { ;
 __p += '\n    <abbr title=\'required\'>*</abbr>\n  ';

--- a/src/scripts/main.coffee
+++ b/src/scripts/main.coffee
@@ -942,9 +942,21 @@ class Formbuilder
       Formbuilder.fields[type].defaultAttributes?(attrs, Formbuilder) || attrs
 
     simple_format: (x) ->
-      x?.replace(/\n/g, '<br />')
+      @escape_html(x)?.replace(/\n/g, '<br />')
+#      x?.replace(/\n/g, '<br />')
     clone: (obj) ->
       JSON.parse(JSON.stringify(obj))
+
+    escape_html: (text) ->
+      map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+      }
+      text.replace(/[&<>"']/g, (m) -> return map[m] )
+
 
   @options:
     BUTTON_CLASS_SELECTOR: 'fb-button btn btn-default'

--- a/src/templates/view/description.html
+++ b/src/templates/view/description.html
@@ -1,3 +1,3 @@
 <span class='help-block'>
-  <%- Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.DESCRIPTION)) %>
+  <%= Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.DESCRIPTION)) %>
 </span>

--- a/src/templates/view/label.html
+++ b/src/templates/view/label.html
@@ -1,5 +1,5 @@
 <label>
-  <span style="color: <%- rf.get(Formbuilder.options.mappings.LABEL_COLOR) || '#000' %>"><%- Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.LABEL)) %>
+  <span style="color: <%- rf.get(Formbuilder.options.mappings.LABEL_COLOR) || '#000' %>"><%= Formbuilder.helpers.simple_format(rf.get(Formbuilder.options.mappings.LABEL)) %>
   <% if (rf.get(Formbuilder.options.mappings.REQUIRED)) { %>
     <abbr title='required'>*</abbr>
   <% } %>


### PR DESCRIPTION
Instead of immediately escaping everything using rivet's `<%-` instead of `<%=`, which has the side effect of escaping the br tag that was introduced by rivets itself (there is a function that converts \n to <br/>), a new HTML escaping function is added into the controller (equivalent to PHP's htmlspecialchars) and the template is returned to use the non-escaping `<%=`