### PR TITLE
In Form Admin, disallow duplication in grids and their children elements. [INTEGRALCS-17212]

### DIFF
--- a/dist/formbuilder.js
+++ b/dist/formbuilder.js
@@ -836,6 +836,7 @@
       if (_.isString(attrs)) {
         attrs = Formbuilder.helpers.defaultFieldAttrs(attrs);
       }
+      attrs.options.disallow_duplication = true;
       attrs.options.grid = {
         col: target.prop('cellIndex'),
         row: target.parents('tr').prop('rowIndex')
@@ -851,6 +852,7 @@
       if (!options.$appendEl) {
         row = responseField.get('options.grid.row');
         col = responseField.get('options.grid.col');
+        responseField.attributes.options.disallow_duplication = true;
         append = builder.wrapperByUuid(responseField.get('parent_uuid'));
         append = append.find('tr:nth-child(' + (row + 1) + ') td:nth-child(' + (col + 1) + ')');
         if (append.length === 1) {
@@ -1541,7 +1543,8 @@
         APPROVAL: {
           APPROVER_TYPE: 'options.approver_type',
           APPROVER_ID: 'options.approver_id'
-        }
+        },
+        DISALLOW_DUPLICATION: 'options.disallow_duplication'
       },
       change: {
         INCLUDE_SCORING: function() {
@@ -2919,7 +2922,8 @@ return __p
 
 this["Formbuilder"]["templates"]["view/base"] = function(obj) {
 obj || (obj = {});
-var __t, __p = '', __e = _.escape;
+var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
+function print() { __p += __j.call(arguments, '') }
 with (obj) {
 __p += '<div class=\'subtemplate-wrapper\'>\n  <div class=\'cover\'></div>\n  ' +
 ((__t = ( Formbuilder.templates['view/conditional']({rf: rf}) )) == null ? '' : __t) +
@@ -2929,9 +2933,17 @@ __p += '<div class=\'subtemplate-wrapper\'>\n  <div class=\'cover\'></div>\n  ' 
 ((__t = ( Formbuilder.fields[rf.get(Formbuilder.options.mappings.TYPE)].view({rf: rf}) )) == null ? '' : __t) +
 '\n\n  ' +
 ((__t = ( Formbuilder.templates['view/description']({rf: rf}) )) == null ? '' : __t) +
-'\n  ' +
+'\n  \n  ';
+ if (rf.get(Formbuilder.options.mappings.DISALLOW_DUPLICATION)) { ;
+__p += '\n    ' +
+((__t = ( Formbuilder.templates['view/remove']({rf: rf}) )) == null ? '' : __t) +
+'\n  ';
+ } else { ;
+__p += '\n    ' +
 ((__t = ( Formbuilder.templates['view/duplicate_remove']({rf: rf}) )) == null ? '' : __t) +
-'\n</div>\n';
+'\n  ';
+ } ;
+__p += '\n</div>\n';
 
 }
 return __p
@@ -2939,15 +2951,24 @@ return __p
 
 this["Formbuilder"]["templates"]["view/base_non_input"] = function(obj) {
 obj || (obj = {});
-var __t, __p = '', __e = _.escape;
+var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
+function print() { __p += __j.call(arguments, '') }
 with (obj) {
 __p += '<div class=\'subtemplate-wrapper\'>\n  <div class=\'cover\'></div>\n  ' +
 ((__t = ( Formbuilder.templates['view/conditional']({rf: rf}) )) == null ? '' : __t) +
 '\n  ' +
 ((__t = ( Formbuilder.fields[rf.get(Formbuilder.options.mappings.TYPE)].view({rf: rf}) )) == null ? '' : __t) +
-'\n  ' +
+'\n\n  ';
+ if (rf.get(Formbuilder.options.mappings.DISALLOW_DUPLICATION)) { ;
+__p += '\n    ' +
+((__t = ( Formbuilder.templates['view/remove']({rf: rf}) )) == null ? '' : __t) +
+'\n  ';
+ } else { ;
+__p += '\n    ' +
 ((__t = ( Formbuilder.templates['view/duplicate_remove']({rf: rf}) )) == null ? '' : __t) +
-'\n</div>\n';
+'\n  ';
+ } ;
+__p += '\n</div>\n';
 
 }
 return __p

--- a/src/scripts/main.coffee
+++ b/src/scripts/main.coffee
@@ -530,6 +530,7 @@ class GridFieldView extends Backbone.View
   createField: (attrs, target) ->
     if _.isString(attrs)
       attrs = Formbuilder.helpers.defaultFieldAttrs(attrs)
+    attrs.options.disallow_duplication = true
     attrs.options.grid =
       col: target.prop('cellIndex')
       row: target.parents('tr').prop('rowIndex')
@@ -540,6 +541,7 @@ class GridFieldView extends Backbone.View
     if not options.$appendEl
       row = responseField.get('options.grid.row')
       col = responseField.get('options.grid.col')
+      responseField.attributes.options.disallow_duplication = true #this disables duplication for both parent and children
       append = builder.wrapperByUuid(responseField.get('parent_uuid'))
       append = append.find('tr:nth-child(' + (row + 1) + ') td:nth-child(' + (col + 1) + ')')
       if append.length == 1
@@ -1061,6 +1063,7 @@ class Formbuilder
       APPROVAL:
         APPROVER_TYPE: 'options.approver_type'
         APPROVER_ID: 'options.approver_id'
+      DISALLOW_DUPLICATION: 'options.disallow_duplication'
 
     change:
       INCLUDE_SCORING: ->

--- a/src/templates/view/base.html
+++ b/src/templates/view/base.html
@@ -6,5 +6,10 @@
   <%= Formbuilder.fields[rf.get(Formbuilder.options.mappings.TYPE)].view({rf: rf}) %>
 
   <%= Formbuilder.templates['view/description']({rf: rf}) %>
-  <%= Formbuilder.templates['view/duplicate_remove']({rf: rf}) %>
+  
+  <% if (rf.get(Formbuilder.options.mappings.DISALLOW_DUPLICATION)) { %>
+    <%= Formbuilder.templates['view/remove']({rf: rf}) %>
+  <% } else { %>
+    <%= Formbuilder.templates['view/duplicate_remove']({rf: rf}) %>
+  <% } %>
 </div>

--- a/src/templates/view/base_non_input.html
+++ b/src/templates/view/base_non_input.html
@@ -2,5 +2,10 @@
   <div class='cover'></div>
   <%= Formbuilder.templates['view/conditional']({rf: rf}) %>
   <%= Formbuilder.fields[rf.get(Formbuilder.options.mappings.TYPE)].view({rf: rf}) %>
-  <%= Formbuilder.templates['view/duplicate_remove']({rf: rf}) %>
+
+  <% if (rf.get(Formbuilder.options.mappings.DISALLOW_DUPLICATION)) { %>
+    <%= Formbuilder.templates['view/remove']({rf: rf}) %>
+  <% } else { %>
+    <%= Formbuilder.templates['view/duplicate_remove']({rf: rf}) %>
+  <% } %>
 </div>


### PR DESCRIPTION
Formbuilder updates including an update to disallow grid duplication, including its child elements, which were fraught with bugs. [INTEGRALCS-17212]

[INTEGRALCS-17212]: https://integralcs.atlassian.net/browse/INTEGRALCS-17212

Inserted into integral branch in: https://github.com/crusepartnership/integral/pull/2383